### PR TITLE
Update stackoverflow-dark.css

### DIFF
--- a/stackoverflow-dark.css
+++ b/stackoverflow-dark.css
@@ -1,5 +1,5 @@
 @namespace url(http://www.w3.org/1999/xhtml);
-@-moz-document domain("stackoverflow.com") {
+@-moz-document regexp("^(?:http(?:s)?:\/\/)?(?:[^\.]+\.)?(stackoverflow)\.com(?:/.*)?") {
 /***************************************************************
  Stackoverflow Dark v2.5.4 (4/27/2014)
  https://github.com/StylishThemes/Stackoverflow-Dark


### PR DESCRIPTION
Changed to match on domain level, so urls like stackoverflow.com would work with no preceeding http / https
