### PR TITLE
Fix elements being underlined and Portuguese Language styling fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@
 
 See the [full changelog](https://github.com/StylishThemes/Stackoverflow-Dark/wiki).
 
+### Version 2.10.2 (6/7/2017)
+
+* Fix many GUI elements being underlined. Fixes [issue #63](https://github.com/StylishThemes/StackOverflow-Dark/issues/63).
+
 ### Version 2.10.0 - 2.10.1 (6/5/2017)
 
 * SO:

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@
 
 See the [full changelog](https://github.com/StylishThemes/Stackoverflow-Dark/wiki).
 
-### Version 2.10.2 (6/7/2017)
+### Version 2.10.2 (???)
 
 * Fix many GUI elements being underlined. Fixes [issue #63](https://github.com/StylishThemes/StackOverflow-Dark/issues/63).
+* Portuguese Language:
+  * Also apply the styling fixes to the main site.
 
 ### Version 2.10.0 - 2.10.1 (6/5/2017)
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See the [full changelog](https://github.com/StylishThemes/Stackoverflow-Dark/wik
 ### Version 2.10.2 (???)
 
 * Fix many GUI elements being underlined. Fixes [issue #63](https://github.com/StylishThemes/StackOverflow-Dark/issues/63).
+* Fix dots having a border around them in the user tab. Fixes [issue #66](https://github.com/StylishThemes/StackOverflow-Dark/issues/66).
 * Portuguese Language:
   * Also apply the styling fixes to the main site.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/StylishThemes/StackOverflow-Dark",
   "homepage": "https://userstyles.org/styles/35345/stackoverflow-dark",
   "scripts": {
-    "authors" : "bash tools/authors.sh"
+    "authors": "bash tools/authors.sh"
   },
   "devDependencies": {
     "grunt": "^1.0.1",

--- a/stackoverflow-dark.css
+++ b/stackoverflow-dark.css
@@ -519,10 +519,6 @@
   }
 
   /* === Style adjustments === */
-  a.question-hyperlink, a.answer-hyperlink, a:hover, a:visited {
-    text-decoration: underline !important;
-  }
-
   .nav a, .post-tag, .comment-link, .tag-synonym-link, a.post-tag:hover, .topbar a,
   .search-form .filter-pane a:hover, .comment-link:hover, .tag-synonym-link:hover {
     text-decoration: none !important;

--- a/stackoverflow-dark.css
+++ b/stackoverflow-dark.css
@@ -1098,7 +1098,7 @@
     color: #777 !important;
   }
 }
-@-moz-document domain("portuguese.meta.stackexchange.com") {
+@-moz-document domain("portuguese.meta.stackexchange.com"), domain("portuguese.stackexchange.com") {
   #hlogo a {
     text-indent: 0 !important;
   }

--- a/stackoverflow-dark.css
+++ b/stackoverflow-dark.css
@@ -417,7 +417,7 @@
     border-right: 0 !important;
   }
   .module, .tabs a, div.message, .full-diff td, .post-tag:not(.required-tag),
-  .wb-outer:not(.wb-selected) {
+  .wb-outer:not(.wb-selected), .page-numbers.dots {
     border-color: transparent !important;
   }
   .left-arrow, .right-arrow {


### PR DESCRIPTION
The portuguese fix is in response to https://github.com/StylishThemes/StackOverflow-Dark/issues/62#issuecomment-306452686.

As for the underlining fix - it will bring style more in line with the default theme, but it will also make certain buttons that are missing hover effects and the like harder to distinguish. These issues should be fixed properly instead of masking them with an underlining styling.

Also, the npm seems to create a `package-lock.json`. The documentation, from what I understand, says to commit it to the repo.