### PR TITLE
Omit background image in body on DBA StackExchange

### DIFF
--- a/stackoverflow-dark.css
+++ b/stackoverflow-dark.css
@@ -933,6 +933,9 @@
 }
 @-moz-document domain("dba.stackexchange.com") {
   /* database administrators */
+  body {
+    background-image: none !important;
+  }
   #hlogo a {
     background-image: url(https://StylishThemes.github.io/StackOverflow-Dark/images/database-admin-logo.svg) !important;
   }


### PR DESCRIPTION
Counterracts the following block found in the all.css (~L23030) that loads for dba.stackexchange.com and disrupts the dark style.
```
body {
 background:#fafafa url('img/bg-site.png?v=8b8aad55bce8') repeat center top
}
```
https://tknk.io/SNyQ fresh SO-Dark install
https://tknk.io/HQlU (more-or-less) vanilla site
https://tknk.io/3dmq my changes

Don't know if you'd rather invert the [image](https://cdn.sstatic.net/Sites/dba/img/bg-site.png?v=8b8aad55bce8).