### PR TITLE
Fix "per page" text on questions page having a border

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@
 
 See the [full changelog](https://github.com/StylishThemes/Stackoverflow-Dark/wiki).
 
+### Version 2.10.21 (2017-10-0?)
+
+* Global: Fix "per page" text on questions page having a border.
+
 ### Version 2.10.20 (2017-09-27)
 
 * SO: Added code to fixed asked date and viewed #. See [PR #88](https://github.com/StylishThemes/StackOverflow-Dark/pull/88); thanks [@jmona789](https://github.com/jmona789)!

--- a/stackoverflow-dark.css
+++ b/stackoverflow-dark.css
@@ -462,7 +462,7 @@
     border-right: 0 !important;
   }
   .module, .tabs a, div.message, .full-diff td, .post-tag:not(.required-tag),
-  .wb-outer:not(.wb-selected), .page-numbers.dots, .p-top-tags .badge-tag {
+  .wb-outer:not(.wb-selected), .page-numbers.dots, .p-top-tags .badge-tag, .page-numbers.desc {
     border-color: transparent !important;
   }
   .left-arrow, .right-arrow {


### PR DESCRIPTION
Before:
![](https://i.imgur.com/D8rndrY.png)

After:
![](https://i.imgur.com/7bMvnS8.png)

Now matches the default theme.