### PR TITLE
no !important for general div text

### DIFF
--- a/stackoverflow-dark.css
+++ b/stackoverflow-dark.css
@@ -508,7 +508,7 @@
   }
 
   /* === Text Color === */
-  div, input, .accepted-answer .post-text, .accepted-answer .user-action-time, #question-header a,
+  input, .accepted-answer .post-text, .accepted-answer .user-action-time, #question-header a,
   .post-text, .user-info, .topbar-dialog .header h3, .topbar-dialog .header h3 a, .topbar-dialog span,
   .search-result .answered .vote-count-post strong, .votes-cast-stats th, .subheader h1, .vote.accepted,
   .message.message-config h1, .message.message-config h2, .message.message-config h3, .message.message-config h4,
@@ -518,6 +518,10 @@
   .salary-calc-inputs span, .salary-survey-dialog .header h3, .title-banner h1, .salary-results-container h1,
   .topbar-dialog h4, .label-key > b {
     color: #ddd !important;
+  }
+  /* no !important for general div text to avoid conflict with other browser extension like Vimium/SurfingKeys */
+  div {
+    color: #ddd;
   }
 
   /* placeholder */


### PR DESCRIPTION
Issue: 
![hint-before-fix](https://user-images.githubusercontent.com/2096033/34590639-24a75c62-f186-11e7-95cc-cbfbae8331cb.png)



No !important for general div text to avoid conflict with other browser extension like [Vimium](https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb)/[SurfingKeys](https://chrome.google.com/webstore/detail/surfingkeys/gfbliohnnapiefjpjlpjnehglfpaknnc) when hint keys are brought up.

After Fix Preview. 



![hint-after-fix](https://user-images.githubusercontent.com/2096033/34590643-2b6289e6-f186-11e7-9d33-67aab5ab6df3.png)


Like this theme a lot. Thanks for sharing!


  