### PR TITLE
text color fix for SurfingKeys extension

### DIFF
--- a/stackoverflow-dark.css
+++ b/stackoverflow-dark.css
@@ -508,7 +508,7 @@
   }
 
   /* === Text Color === */
-  input, .accepted-answer .post-text, .accepted-answer .user-action-time, #question-header a,
+  div, input, .accepted-answer .post-text, .accepted-answer .user-action-time, #question-header a,
   .post-text, .user-info, .topbar-dialog .header h3, .topbar-dialog .header h3 a, .topbar-dialog span,
   .search-result .answered .vote-count-post strong, .votes-cast-stats th, .subheader h1, .vote.accepted,
   .message.message-config h1, .message.message-config h2, .message.message-config h3, .message.message-config h4,
@@ -519,9 +519,9 @@
   .topbar-dialog h4, .label-key > b {
     color: #ddd !important;
   }
-  /* no !important for general div text to avoid conflict with other browser extension like Vimium/SurfingKeys */
-  div {
-    color: #ddd;
+  /* patch for hint text of SurfingKeys browser extension */
+  #sk-hint div {
+    color: #000 !important;
   }
 
   /* placeholder */


### PR DESCRIPTION
a fix for the issue mentioned in 
https://github.com/StylishThemes/StackOverflow-Dark/pull/99

put the div text color back and make a specific rule for(`#sk-hint`) the hints instead. 

After fix: 

<img width="882" alt="screen shot 2018-01-06 at 1 32 25 pm" src="https://user-images.githubusercontent.com/2096033/34642734-1afc1fa2-f2e6-11e7-9947-31387bf84a23.png">
