### PR TITLE
Secondary jobs identifier now has dark theme

### DIFF
--- a/stackoverflow-dark.css
+++ b/stackoverflow-dark.css
@@ -239,7 +239,8 @@
   }
 
   .answer, #system-message, .commentlist, .revision td, #hero-content, .mdhelp-tabs .selected, .tabs .selected,
-  .rep-card .rep-col, .sort select, .-job._highlighted, .MathJax_MenuDisabled, .gsc-option-menu-item-highlighted {
+  .rep-card .rep-col, .sort select, .-job._highlighted, .MathJax_MenuDisabled, .gsc-option-menu-item-highlighted,
+  .secondary-job-results-identifier {
     background: #232323 !important;
     color: #999 !important;
   }


### PR DESCRIPTION
Update the secondary job results identifier to have a dark background like the highlighted jobs do.

Before:
![before](https://user-images.githubusercontent.com/13175844/38545904-849dd4f8-3cee-11e8-8165-19395a8159f1.JPG)

After:
![after](https://user-images.githubusercontent.com/13175844/38545912-88bf2de8-3cee-11e8-8076-700db0fecdb5.JPG)
