### PR TITLE
Add .site-footer--container to transparent rule to fix white footer on askubuntu.com

### DIFF
--- a/stackoverflow-dark.css
+++ b/stackoverflow-dark.css
@@ -420,7 +420,8 @@
   #profile-side #side-menu a, .sidebar-profile .-header, .sidebar-profile .-footer,
   #popup-next-badge .-header, .popup-close .-link, .job-cover-image.-no-image, #job-detail,
   .s-footer .-container, .p-top-tags .badge-tag, .gsc-webResult.gsc-result, .gsc-imageResult,
-  .gsc-cursor-page, .gsc-cursor-current-page, .metaInfo .owner, #content > .subheader, header.job-details--header {
+  .gsc-cursor-page, .gsc-cursor-current-page, .metaInfo .owner, #content > .subheader,
+  header.job-details--header, .site-footer--container {
     background-color: transparent !important;
   }
 


### PR DESCRIPTION
[Askubuntu](https://askubuntu.com/) has a .site-footer--container with white color. This fixes it by adding it to the general background transparent rule.

![](https://i.imgur.com/IMUIjdS.png),