### PR TITLE
Add gaming.stackexchange.com - Close #139

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   </a>
 </p>
 
-This dark theme applied to Stack Overflow and almost all Stack Exchange sites (except [Gaming](http://gaming.stackexchange.com/) and [Area 51](http://area51.stackexchange.com/)).
+This dark theme applied to Stack Overflow and almost all Stack Exchange sites (except [Area 51](http://area51.stackexchange.com/)).
 
 ## Preview
 

--- a/stackoverflow-dark.user.css
+++ b/stackoverflow-dark.user.css
@@ -87,7 +87,7 @@ domain("superuser.com"),
 domain("stackapps.com"),
 domain("mathoverflow.net"),
 domain("askubuntu.com"),
-regexp("^https?://((?!(www|area51|gaming)).*\\.)?stackexchange\\.com.*") {
+regexp("^https?://((?!(www|area51)).*\\.)?stackexchange\\.com.*") {
   /**
    * Stack Overflow Dark
    * https://github.com/StylishThemes/StackOverflow-Dark
@@ -95,7 +95,6 @@ regexp("^https?://((?!(www|area51|gaming)).*\\.)?stackexchange\\.com.*") {
    * ** Will apply to almost all Stack Exchange Sites **
    * Except:
    * - Area 51 (area51.stackexchange.com)
-   * - Gaming (gaming.stackexchange.com)
    * ** Please open an issue to report sites where the style breaks **
    * https://github.com/StylishThemes/StackOverflow-Dark/issues
    * previous version information contained at the userstyles site
@@ -983,7 +982,7 @@ regexp("^https?://((?!(www|area51|gaming)).*\\.)?stackexchange\\.com.*") {
 |  _| | | | -_| .'| '_|_ -|
 |_| |_____|___|__,|_,_|___|
 */
-@-moz-document regexp("^https?://((?!(www|area51|gaming)).*\\.)?stackexchange.com.*") {
+@-moz-document regexp("^https?://((?!(www|area51)).*\\.)?stackexchange.com.*") {
   /* login screen StackExchange logo replacement */
   .login-page .se-logo {
     -moz-box-sizing: border-box !important;


### PR DESCRIPTION
Simply removed the exclusion of [gaming.stackexchange.com](https://gaming.stackexchange.com/) from the rules. I haven't edited any rules, as it looks fairly standard compared to the other sites on the network. The images on the footer/header could be made transparent for consistency, but I felt the blue worked ok, so I didn't change it, as I'm not sure what is desired. I didn't bump the version because I'm not sure the style looks as expected.

I also did notice that there seems to have a lot of deprecated rules, specially on the rules that apply only to some sites on the network. I believe it is expected due to the sheer amount of sites and different styles, so it's impossible to keep up unless people complain their site is somehow broken. I decided to err on the side of caution and not touch them, as everything mostly looks fine.