### PR TITLE
Added opacity transition for post-images

### DIFF
--- a/stackoverflow-dark.user.css
+++ b/stackoverflow-dark.user.css
@@ -995,6 +995,7 @@ regexp("^https?://((?!(www|area51)).*\\.)?stackexchange\\.com.*") {
     background: #fff !important;
     opacity: /*[[img-opacity]]*/;
     border: #fff 2px solid !important;
+    transition: opacity .5s ease;
   }
   .post-text img:hover {
     opacity: 1 !important;


### PR DESCRIPTION
Currently, on mouse-over, the opacity of the image is set to 1. Added an opacity transition to make the change less choppy.