### PR TITLE
Fix issue #158: Fix dark theme on sites with a bright background image

### DIFF
--- a/stackoverflow-dark.user.css
+++ b/stackoverflow-dark.user.css
@@ -1854,3 +1854,8 @@ regexp("^https?://((?!(www|area51)).*\\.)?stackexchange\\.com.*") {
     color: #b571e2 !important;
   }
 }
+@-moz-document domain("askubuntu.com"), regexp("^https?://((anime|bicycles|blender|crypto|codereview|dba|diy|electronics|emacs|gamedev|gis|graphicdesign|math|rpg|softwarerecs|unix|worldbuilding)\\.)?stackexchange\\.com.*") {
+  body {
+    background-image: none !important;
+  }
+}


### PR DESCRIPTION
On pages with a bright background image, that image cover the dark background color. This commit fix issue #158 by setting background-image to none.