### PR TITLE
Fix owner comment-user background color

### DIFF
--- a/stackoverflow-dark.user.css
+++ b/stackoverflow-dark.user.css
@@ -1617,6 +1617,11 @@ regexp("^https?:\/\/((?!area51)\w+\.)*?stackexchange\.com.*") {
   #mainbar a.comment-user {
     color: #5b93ff !important;
   }
+  
+  a.comment-user.owner {
+    background-color: #124fc3 !important;
+  }
+  
   /* patch for hint text of SurfingKeys browser extension */
   #sk_hints div {
     color: #000 !important;


### PR DESCRIPTION
The background was `#111`, so it looks like the comment background, changed it to something more highlighted.
![image](https://user-images.githubusercontent.com/26777129/62806901-b3a57200-bafc-11e9-8c21-5745c6752e78.png)
