### PR TITLE
Fix votes badge overriding answered badge

### DIFF
--- a/stackoverflow-dark.user.css
+++ b/stackoverflow-dark.user.css
@@ -2288,7 +2288,7 @@ regexp("^https?:\/\/stackoverflow.[^\.]*\.com.*") {
     color: #ddd;
     border-bottom-color: /*[[base-color]]*/ !important;
   }
-  .s-badge__votes {
+  .s-badge__votes:not(.s-badge__answered) {
     border-color: #444;
     background-color: #181818;
     color: #eee;


### PR DESCRIPTION
Voted questions/answers that have accepted answer/have been accepted shouldn't look like the other (should have green emphasize).
You may find occurrences of it in the Activity tab in your profile.